### PR TITLE
Deal with amazon linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 #
 # Sourdough
 #
-# Copyright 2015 Joe Block <jpb@unixorn.net>
+# Copyright 2017 Joe Block <jpb@unixorn.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Deal with oddities on Amazon linux instances

* Amazon linux instances don't have 'amazon' in their dmidata, so we determine we're in EC2 by whether or not we can read the instance's account data from the metadata URL
* Clean up how we get our connection to EC2


