### PR TITLE
Cope when run outside ec2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,17 +1,29 @@
 # Sourdough
 
-# 0.4
+## 0.5
+
+Clean up code so we work when run out of ec2 now that we have a data center we care about.
+
+* Stop trying to get boto ec2 connections when we aren't in ec2. Oops!
+
+Try really hard to get a runlist and environment
+
+* Load environment from `sourdough.toml` if we can't find a tag or knob file
+* Load runlist from `sourdough.toml` if we can't find a tag or knob file
+* Add default values for environment, region and runlist if they aren't in `sourdough.toml` and aren't in a tag or knob file.
+
+## 0.4
 
 Cope with rename on github from bigriver.sourdough to sourdough.
 
-# 0.3
+## 0.3
 
 Allow specifying a chef server url instead of defaulting to Hosted Chef
 
-# 0.2
+## 0.2
 
 First public version
 
-# 0.0.1
+## 0.0.1
 
 * Begin.

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,5 @@ wheel:
 
 develop:
 	python setup.py develop
+
+u: upload

--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,9 @@
 [![Issue Count](https://codeclimate.com/github/unixorn/sourdough/badges/issue_count.svg)](https://codeclimate.com/github/unixorn/sourdough)
 [![GitHub stars](https://img.shields.io/github/stars/unixorn/sourdough.svg)](https://github.com/unixorn/git-extra-commands/stargazers)
 
-Sourdough is a tool to install chef-client during instance boot.
+Sourdough is a tool to install `chef-client` during instance boot, or to run `chef-client` after boot.
+
+Sourdough reads the **Environment** and **Runlist** EC2 tags and runs `chef-client` with those settings so you can update an instance's Chef settings just by tweaking its tags. This also lets you see what runlist and environment an instance has using just the AWS webui, so no more having to correlate Chef information for your instances in two places.
 
 # FAQs
 
@@ -18,7 +20,7 @@ If we're in EC2, we look for a Node tag/knob. If a Node tag or knob exists, our 
 
 If the node tag and knob don't exist, we look for a Hostname tag or knob and set the node name to **AWS_REGION-HOSTNAME_TAGKNOB**.
 
-If the Hostname tag or knob are both missing we fail back to reading the output of `hostname`.
+If the Hostname tag or knob are both missing we fail back to reading the output of `hostname` which is better than nothing.
 
 ### Outside EC2
 
@@ -32,8 +34,8 @@ contents of that - if there's no knob file we use the output of
 
 The first thing we do is check for `/etc/knobs/Runlist`. If that's present, we set the runlist to the contents of that file.
 
-If there is no `/etc/knobs/Runlist` file, we read the instance's **Runlist** tag and set the runlist to that.
+If there is no `/etc/knobs/Runlist` file, we read the instance's **Runlist** tag and set the runlist to that, and if there is no Runlist tag we look for a **default_runlist** entry in `/etc/sourdough/sourdough.toml`
 
 ## What Chef environment does Sourdough use
 
-Similarly to how it determines the Runlist, `sourdough` looks for `/etc/knobs/Environment` and if that is missing, the **Environment** tag for the instance.
+Similarly to how it determines the Runlist, `sourdough` looks for `/etc/knobs/Environment` and if that is missing, the **Environment** tag for the instance, and if that is missing, looks for a **default_environment** entry in `/etc/sourdough/sourdough.toml`

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
-#
 # Sourdough
 #
-# Copyright 2017 Joe Block <jpb@unixorn.net>
+# Copyright 2017-2018 Joe Block <jpb@unixorn.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
+'''
 setup.py for sourdough
-"""
+'''
 
 import os
 import shutil
@@ -36,15 +35,15 @@ def system_call(command):
   return p.stdout.read()
 
 
-name = "sourdough"
-version = "0.5.%s" % (system_call('git rev-list HEAD --count').strip())
+name = 'sourdough'
+version = '0.5.' + system_call('git rev-list HEAD --count').strip().decode('utf-8')
 
 
 class CleanCommand(Command):
   '''
   Add a clean option to setup.py's commands
   '''
-  description = "Clean up"
+  description = 'Clean up'
   user_options = []
 
 
@@ -58,10 +57,10 @@ class CleanCommand(Command):
 
   def run(self):
     assert os.getcwd() == self.cwd, "Must be in package root: %s" % self.cwd
-    if os.path.isdir("build"):
-      shutil.rmtree("build")
-    if os.path.isdir("dist"):
-      shutil.rmtree("dist")
+    if os.path.isdir('build'):
+      shutil.rmtree('build')
+    if os.path.isdir('dist'):
+      shutil.rmtree('dist')
 
 
 setup(
@@ -95,6 +94,7 @@ setup(
       "sourdough = %s.cli.commands:sourdoughDriver" % name,
       "sourdough-bootstrap = %s.sourdough:infect" % name,
       "sourdough-deregister = %s.sourdough:deregisterFromChef" % name,
+      "sourdough-runner = %s.sourdough:runner" % name,
       "sourdough-starter = %s.sourdough:runner" % name
     ]
   }

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def system_call(command):
 
 
 name = "sourdough"
-version = "0.4.%s" % (system_call('git rev-list HEAD --count').strip())
+version = "0.5.%s" % (system_call('git rev-list HEAD --count').strip())
 
 
 class CleanCommand(Command):


### PR DESCRIPTION
Clean up code so we work when run out of ec2 now that we have a data center we care about.

* Stop trying to get boto ec2 connections when we aren't in ec2. Oops!

Try really hard to get a runlist and environment

* Load environment from `sourdough.toml` if we can't find a tag or knob file
* Load runlist from `sourdough.toml` if we can't find a tag or knob file
* Add default values for environment, region and runlist if they aren't in `sourdough.toml` and aren't in a tag or knob file.