### PR TITLE
Bump version number now that we have a disable function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def system_call(command):
 
 
 name = 'sourdough'
-version = '0.6.0'
+version = '0.7.0'
 
 
 class CleanCommand(Command):


### PR DESCRIPTION
Forgot to bump the version number when @mathicastlight submitted the disable function changes, so pypi upload failed.