### PR TITLE
Update getAWSAccountID exception handling.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Sourdough
 
+## 0.9.2
+
+* Update `getAWSAccountID` so it treats any exceptions as not being in EC2, not just `URLError` ones.
+
+## 0.9.1
+
+* Add new `pyvim` and `pyvmomi` dependencies introduced in 0.9 to `setup.py` so they are pulled in automatically by `pip`.
+
 ## 0.9
 
 * Add VMware Tags support

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def system_call(command):
 
 
 name = 'sourdough'
-version = '0.9.1'
+version = '0.9.2'
 
 
 class CleanCommand(Command):

--- a/sourdough/sourdough.py
+++ b/sourdough/sourdough.py
@@ -137,7 +137,7 @@ def getAWSAccountID():
   link = "http://169.254.169.254/latest/dynamic/instance-identity/document"
   try:
     conn = urllib2.urlopen(url=link, timeout=5)
-  except urllib2.URLError:
+  except:
     return '0'
   jsonData = json.loads(conn.read())
   return jsonData['accountId']


### PR DESCRIPTION
* Update `getAWSAccountID` so it treats any exceptions as not being in EC2, not just `URLError` ones.