### PR TITLE
Bump version to 0.9.4

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,9 +1,13 @@
 # Sourdough
 
-## 0.9.3
+## 0.9.4
 
 * Fix attribute resolution in VMWare
 * Cache knobs and VMWare attributes
+
+## 0.9.3
+
+Missing change notes.
 
 ## 0.9.2
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def system_call(command):
 
 
 name = 'sourdough'
-version = '0.9.3'
+version = '0.9.4'
 
 
 class CleanCommand(Command):


### PR DESCRIPTION
Previous 0.9.3 release didn't get release notes, updated ChangeLog.md accordingly and bumped version to 0.9.4