### PR TITLE
Use default route interface IP address when searching for tags

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Sourdough
 
+## 0.9.5
+
+* Use correct IP address when searching for tags in VSphere
+
 ## 0.9.4
 
 * Fix attribute resolution in VMWare

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def system_call(command):
 
 
 name = 'sourdough'
-version = '0.9.4'
+version = '0.9.5'
 
 
 class CleanCommand(Command):

--- a/sourdough/sourdough.py
+++ b/sourdough/sourdough.py
@@ -192,13 +192,25 @@ def readKnobOrTagValue(name, connection=None, knobDirectory='/etc/knobs'):
       return None
   return None # No knobfile and we're either outside EC2/VMware or no tag either
 
+def get_ip():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        # doesn't even have to be reachable
+        s.connect(('10.255.255.255', 1))
+        IP = s.getsockname()[0]
+    except:
+        IP = '127.0.0.1'
+    finally:
+        s.close()
+    return IP
+
 def readVirtualMachineTag(tagName):
     '''
     Read Tags / Attributes from VM
 
     :rtype: str
     '''
-    vm_ip = socket.gethostbyname(socket.gethostname())
+    vm_ip = get_ip()
 
     if vm_ip not in vmwareTags:
       vmwareTags[vm_ip] = {}


### PR DESCRIPTION
Hostnames are resolving to `169.254.1.1` which is a dummy IP address
which can not be used for searching in VSphere. Switch to using the
default IP address from routes table of the node.