### PR TITLE
Fix failure when can't connect to VMWare server

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def system_call(command):
 
 
 name = 'sourdough'
-version = '0.9.5'
+version = '0.9.6'
 
 
 class CleanCommand(Command):

--- a/sourdough/sourdough.py
+++ b/sourdough/sourdough.py
@@ -227,13 +227,16 @@ def readVirtualMachineTag(tagName):
         hostname = v.get('hostname')
         username = v.get('user')
         password = v.get('password')
-        si= SmartConnect(host=hostname, user=username, pwd=password, sslContext=secure)
-        searcher = si.content.searchIndex
-        vm = searcher.FindByIp(ip=vm_ip, vmSearch=True)
-        if vm:
-          f = si.content.customFieldsManager.field
-          for k, v in [(x.name, v.value) for x in f for v in vm.customValue if x.key == v.key]:
-            vmwareTags[vm_ip][k] = v
+        try:
+          si= SmartConnect(host=hostname, user=username, pwd=password, sslContext=secure)
+          searcher = si.content.searchIndex
+          vm = searcher.FindByIp(ip=vm_ip, vmSearch=True)
+          if vm:
+            f = si.content.customFieldsManager.field
+            for k, v in [(x.name, v.value) for x in f for v in vm.customValue if x.key == v.key]:
+              vmwareTags[vm_ip][k] = v
+        except socket.error:
+          print 'Cannot connect to %s to read VMWare tags' % hostname
 
     if tagName in vmwareTags[vm_ip]:
       return vmwareTags[vm_ip][tagName]


### PR DESCRIPTION
If we can't connect to the VMWare server we now treat that as not
getting VM tags instead of dying.