### PR TITLE
Update tag read algorithm on VMWare

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,21 @@
 # Sourdough
 
+## 0.12.0
+
+Fixed version of 0.10.0
+
+Deal with bad behavior by VSphere/VMWare. We sometimes see our VSphere host reject connections, causing some chef runs to get the default runlist instead of the real one.
+
+To deal with this, when we are able to read tag data, we write the tag data to a knob file, so on future runs we can load from there if VSphere is having a tizzy.
+
+## 0.11.0
+
+Revert bad 0.10.0 version
+
+## 0.10.0
+
+Removed. Broke build due to bad testing.
+
 ## 0.9.5
 
 * Use correct IP address when searching for tags in VSphere

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def system_call(command):
 
 
 name = 'sourdough'
-version = '0.11.0'
+version = '0.12.0'
 
 
 class CleanCommand(Command):

--- a/sourdough/sourdough.py
+++ b/sourdough/sourdough.py
@@ -172,6 +172,7 @@ def readKnobOrTag(name, connection=None, knobDirectory='/etc/knobs'):
 
   return knobsCache[name]
 
+
 def readKnobOrTagValue(name, connection=None, knobDirectory='/etc/knobs'):
   '''
   Read a knob file or EC2 instance tag
@@ -212,17 +213,19 @@ def readKnobOrTagValue(name, connection=None, knobDirectory='/etc/knobs'):
       return None
   return None # No knobfile and we're either outside EC2/VMware or no tag either
 
+
 def get_ip():
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    try:
-        # doesn't even have to be reachable
-        s.connect(('10.255.255.255', 1))
-        IP = s.getsockname()[0]
-    except:
-        IP = '127.0.0.1'
-    finally:
-        s.close()
-    return IP
+  s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+  try:
+    # doesn't even have to be reachable
+    s.connect(('10.255.255.255', 1))
+    IP = s.getsockname()[0]
+  except:
+    IP = '127.0.0.1'
+  finally:
+    s.close()
+  return IP
+
 
 def readVirtualMachineTag(tagName):
     '''

--- a/sourdough/sourdough.py
+++ b/sourdough/sourdough.py
@@ -130,6 +130,26 @@ def readKnob(knobName, knobDirectory='/etc/knobs'):
     return None
 
 
+def writeKnob(name, value, knobDirectory='/etc/knobs'):
+  '''
+  Write to a knob file
+
+  :param str name: Which knob to write
+  :param str value: What value to write to the knobfile
+  '''
+  assert isinstance(knobDirectory, basestring), ("knobDirectory must be a string but is %r" % knobDirectory)
+  assert isinstance(name, basestring), ("name must be a string but is %r" % name)
+  assert isinstance(value, basestring), ("value must be a string but is %r" % value)
+
+  knobPath = "%s/%s" % (knobDirectory, name)
+  if not os.path.isdir(knobDirectory):
+    print 'directory %s does not exist, creating it' % knobDirectory
+    systemCall('mkdir -p %s' % knobDirectory)
+  with open(knobPath, 'w') as knobFile:
+    print 'Writing %s to %s' % (value, knobFile)
+    knobFile.write(value)
+
+
 def getAWSAccountID():
   '''
   Print an instance's AWS account number or 0 when not in EC2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you're unsure about anything in this checklist, don't hesitate to create a PR and ask. I'm happy to help! -->

# Description

Deal with bad behavior by VSphere/VMWare. We sometimes see our VSphere host reject connections, causing some chef runs to get the default runlist instead of the real one.

To deal with this, we write the tag data to a knob file, so on future runs we load from there and don't need to care if VSphere is having a tizzy.

This does mean that changing a VSphere tag will not affect the parameters of a given VM, but in our use case, we never change the tags after a VM is spun up anyway.

# Copyright Assignment

- [x] This project is covered by the [Apache License](https://github.com/unixorn/sourdough/blob/master/License.md), and I agree to contribute this PR under the terms of the license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
