### PR TITLE
Refactor VMware detection and tag handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def system_call(command):
 
 
 name = 'sourdough'
-version = '0.12.0'
+version = '0.12.1'
 
 
 class CleanCommand(Command):

--- a/sourdough/sourdough.py
+++ b/sourdough/sourdough.py
@@ -395,16 +395,19 @@ def inVMware():
   '''
   Detect if we're running in VMware.
 
-  Check the dmsg output if it matches VMware return True
+  Check ohai output - key hostnamectl.virtualization tells us what hypervisor we're on.
 
   :rtype: bool
   '''
-  hypervisor = subprocess.check_output("dmesg | grep 'Hypervisor detected' | awk '{print $NF}'", shell=True).strip()
-  if hypervisor == 'VMware':
-    return True
-  else:
+  try:
+    hypervisor = subprocess.check_output("ohai | jq '.hostnamectl.virtualization' | grep -c vmware", shell=True).strip()
+    if hypervisor == '1':
+      return True
+    else:
+      return False
+  except subprocess.CalledProcessError:
+    # grep exits 1 when it can't find the search string
     return False
-
 
 def generateNodeName():
   '''

--- a/sourdough/sourdough.py
+++ b/sourdough/sourdough.py
@@ -52,6 +52,7 @@ DEFAULT_WAIT_FOR_ANOTHER_CONVERGE = 600
 knobsCache = {}
 vmwareTags = {}
 
+
 def amRoot():
   '''
   Are we root?
@@ -281,6 +282,7 @@ def readVirtualMachineTag(tagName):
       return vmwareTags[vm_ip][tagName]
     else:
       return None
+
 
 def loadHostname():
   '''

--- a/sourdough/sourdough.py
+++ b/sourdough/sourdough.py
@@ -149,7 +149,7 @@ def writeKnob(name, value, knobDirectory='/etc/knobs'):
     print 'directory %s does not exist, creating it' % knobDirectory
     systemCall('mkdir -p %s' % knobDirectory)
   with open(knobPath, 'w') as knobFile:
-    print 'Writing %s to %s' % (value, knobFile)
+    print 'writeKnob: Writing %s to %s' % (value, knobPath)
     knobFile.write(value)
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you're unsure about anything in this checklist, don't hesitate to create a PR and ask. I'm happy to help! -->

# Description

I was assuming that failing to connect to VMWare would throw an exception, but per @jsmilani it is still glitching.

We now explicitly check for no data coming back too and then fail over to reading the knob files

`inVMware()` was glitchy - it would eventually fail to correctly detect that it was on VMWare. The old code was looking at the output of `dmesg` to detect that it was running on VMware. That was fine immediately after boot, but various events would eventually overwrite the `dmesg` log and break VMWare detection.

This was masked because it turned out that the code in `readTagOrKnob` was mistakenly checking the _existence_ of the inVMware function instead of its return value.

* Refactored `readTagOrKnob()` to make it less brittle
* Made `inVMware()` work even well after VM boot

# Copyright Assignment

- [x] This project is covered by the [Apache License](https://github.com/unixorn/sourdough/blob/master/License.md), and I agree to contribute this PR under the terms of the license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
