### PR TITLE
Make vSphere tag reading more robust.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,17 @@
 # Sourdough
 
+## 0.12.2
+
+### Working around more vSphere shenanigans
+
+* Switched from using IP address to UUID when looking up tag data. We were using the VM's IP address as the key when requesting tag information. This turned out to be a bad idea because if the machine has several IPs, the one `getIP()` picked wasn't necessarily the one vSphere was using as the main key, so you wouldn't always be able to get the tag data from vSphere when searching by IP, which sucks.
+* For efficiency, we now check the `vmwareTags` dict to see if we've already read a tag value  _before_ reading all the tags from the hypervisor. We also load all available tags into the cache whenever we scan for a tag that isn't already cached.
+* Added `detectVSphereHost()`, `loadVSphereSettings()` and `writeVSphereSettings()` so we don't retry connecting to all the vSphere hosts listed in `vmware.toml` every time we read a tag, with the associated delays waiting for timeouts trying to connect to unreachable hypervisors. Now we store that information in a knob file so future `sourdough` runs won't have to grovel through the entire hypervisor list.
+* Added a debugging flag file, `/etc/sourdough/debug-sourdough`.  When the flag is present, `sourdough` won't actually start `chef-client` so you can debug vSphere issues faster.
+* Renamed `get_ip()` to `getIP()` for naming consistency
+* Converted a lot of crappy `print` statements to proper `logger` usage
+* Updated and created a bunch of missing/crappy docstrings
+
 ## 0.12.0
 
 Fixed version of 0.10.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def system_call(command):
 
 
 name = 'sourdough'
-version = '0.12.1'
+version = '0.12.2'
 
 
 class CleanCommand(Command):

--- a/sourdough/sourdough.py
+++ b/sourdough/sourdough.py
@@ -178,7 +178,7 @@ def getAWSAccountID():
 
 def readKnobOrTag(name, connection=None, knobDirectory='/etc/knobs'):
   '''
-  Read tag/knob data from the kobsCache if present, set the cache if not.
+  Read tag/knob data from the knobsCache if present, set the cache if not.
 
   :param str name: Name of the tag we want to load
   :param str knobDirectory: What directory to search for knob files
@@ -245,7 +245,7 @@ def readKnobOrTagValue(name, connection=None, knobDirectory='/etc/knobs'):
   return data
 
 
-def get_ip():
+def getIP():
   '''
   Determine our IP
 
@@ -337,7 +337,7 @@ def detectVSphereHost():
   :rtype dict:
   '''
   loadSharedLogger()
-  vm_ip = get_ip()
+  vm_ip = getIP()
 
   this.logger.debug('Trying to find a vsphere host')
   this.logger.debug('vmwareTags: %r', vmwareTags)

--- a/sourdough/sourdough.py
+++ b/sourdough/sourdough.py
@@ -96,8 +96,7 @@ def getCustomLogger(name):
 
   logLevel = readKnob('logLevel')
   if not logLevel:
-    # logLevel = 'INFO'
-    logLevel = 'DEBUG'
+    logLevel = 'INFO'
 
   # If they don't specify a valid log level, err on the side of verbosity
   if logLevel.upper() not in validLogLevels:

--- a/sourdough/sourdough.py
+++ b/sourdough/sourdough.py
@@ -279,7 +279,7 @@ def loadVSphereSettings(knobName=DEFAULT_VSPHERE_KNOB, knobDirectory=DEFAULT_KNO
   loadSharedLogger()
   fpath = "%s/%s" % (knobDirectory, knobName)
   if os.path.isfile(fpath):
-    this.logger.debug('Reading cached vsphere data from %s', fpath)
+    this.logger.debug('Reading cached vSphere data from %s', fpath)
     try:
       with open(fpath, 'r') as vmwareConfig:
         vsphereSettings = toml.load(vmwareConfig)
@@ -412,15 +412,14 @@ def readVirtualMachineTag(tagName):
       si= SmartConnect(host=hostname, user=username, pwd=password, sslContext=secure)
       this.logger.debug('SmartConnect succeeded')
       searcher = si.content.searchIndex
-      this.logger.debug('Searching for VM for %s', uuid)
-      # vm = searcher.FindByIp(ip=vm_ip, vmSearch=True)
+      this.logger.debug('Searching for VM for UUID %s', uuid)
       vm = searcher.FindByUuid(uuid=uuid, vmSearch=True)
       if vm:
-        this.logger.debug('Found VM object for %s, loading tags', uuid)
+        this.logger.debug('Found VM object for UUID %s, loading tags', uuid)
         f = si.content.customFieldsManager.field
         for k, v in [(x.name, v.value) for x in f for v in vm.customValue if x.key == v.key]:
           vmwareTags[k] = v
-          this.logger.debug('Found tag:%s=%s', k, v)
+          this.logger.debug('Caching tag:%s=%s', k, v)
       else:
         this.logger.error('Could not find a vSphere VM record for %s', uuid)
     except socket.error:
@@ -570,6 +569,7 @@ def inVMware():
   except subprocess.CalledProcessError:
     # grep exits 1 when it can't find the search string
     return False
+
 
 def generateNodeName():
   '''

--- a/sourdough/sourdough.py
+++ b/sourdough/sourdough.py
@@ -46,7 +46,7 @@ DEFAULT_NODE_PREFIX = 'chef_node'
 DEFAULT_REGION = 'undetermined-region'
 DEFAULT_RUNLIST = 'nucleus'
 DEFAULT_TOML_FILE = '/etc/sourdough/sourdough.toml'
-DEFFAULT_VMWARE_CONFIG = '/etc/sourdough/vmware.toml'
+DEFAULT_VMWARE_CONFIG = '/etc/sourdough/vmware.toml'
 DEFAULT_WAIT_FOR_ANOTHER_CONVERGE = 600
 
 knobsCache = {}
@@ -230,7 +230,6 @@ def readKnobOrTagValue(name, connection=None, knobDirectory='/etc/knobs'):
   return data
 
 
-
 def get_ip():
   s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
   try:
@@ -258,9 +257,10 @@ def readVirtualMachineTag(tagName):
       secure=ssl.SSLContext(ssl.PROTOCOL_TLSv1)
       secure.verify_mode=ssl.CERT_NONE
       try:
-        with open(DEFFAULT_VMWARE_CONFIG, 'r') as vmwareConfig:
+        with open(DEFAULT_VMWARE_CONFIG, 'r') as vmwareConfig:
           vcenters = toml.load(vmwareConfig)['vcenters']
       except IOError as error:
+        print "Could not open %s" % DEFAULT_VMWARE_CONFIG
         return None
 
       for k,v in vcenters.iteritems():

--- a/sourdough/sourdough.py
+++ b/sourdough/sourdough.py
@@ -42,11 +42,13 @@ this = sys.modules[__name__]
 # Set some module constants
 CHEF_D = '/etc/chef'
 DEFAULT_ENVIRONMENT = '_default'
+DEFAULT_KNOB_DIRECTORY = '/etc/knobs'
 DEFAULT_NODE_PREFIX = 'chef_node'
 DEFAULT_REGION = 'undetermined-region'
 DEFAULT_RUNLIST = 'nucleus'
 DEFAULT_TOML_FILE = '/etc/sourdough/sourdough.toml'
 DEFAULT_VMWARE_CONFIG = '/etc/sourdough/vmware.toml'
+DEFAULT_VSPHERE_KNOB = '/etc/knobs/vsphere_host'
 DEFAULT_WAIT_FOR_ANOTHER_CONVERGE = 600
 
 knobsCache = {}
@@ -148,9 +150,12 @@ def writeKnob(name, value, knobDirectory='/etc/knobs'):
   if not os.path.isdir(knobDirectory):
     print 'directory %s does not exist, creating it' % knobDirectory
     systemCall('mkdir -p %s' % knobDirectory)
-  with open(knobPath, 'w') as knobFile:
-    print 'writeKnob: Writing %s to %s' % (value, knobPath)
-    knobFile.write(value)
+  if value is not None:
+    with open(knobPath, 'w') as knobFile:
+      print "writeKnob: Writing %s to %s" % (value, knobPath)
+      knobFile.write(value)
+  else:
+    print "writeKnob: %s has a value of %s, skipping write" % (name, value)
 
 
 def getAWSAccountID():

--- a/sourdough/sourdough.py
+++ b/sourdough/sourdough.py
@@ -244,44 +244,45 @@ def get_ip():
 
 
 def readVirtualMachineTag(tagName):
-    '''
-    Read Tags / Attributes from VM
+  '''
+  Read Tags / Attributes from VM
 
-    :rtype: str
-    '''
-    vm_ip = get_ip()
+  :rtype: str
+  '''
+  vm_ip = get_ip()
 
-    if vm_ip not in vmwareTags:
-      vmwareTags[vm_ip] = {}
+  if vm_ip not in vmwareTags:
+    vmwareTags[vm_ip] = {}
 
-      secure=ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-      secure.verify_mode=ssl.CERT_NONE
-      try:
-        with open(DEFAULT_VMWARE_CONFIG, 'r') as vmwareConfig:
-          vcenters = toml.load(vmwareConfig)['vcenters']
-      except IOError as error:
-        print "Could not open %s" % DEFAULT_VMWARE_CONFIG
-        return None
-
-      for k,v in vcenters.iteritems():
-        hostname = v.get('hostname')
-        username = v.get('user')
-        password = v.get('password')
-        try:
-          si= SmartConnect(host=hostname, user=username, pwd=password, sslContext=secure)
-          searcher = si.content.searchIndex
-          vm = searcher.FindByIp(ip=vm_ip, vmSearch=True)
-          if vm:
-            f = si.content.customFieldsManager.field
-            for k, v in [(x.name, v.value) for x in f for v in vm.customValue if x.key == v.key]:
-              vmwareTags[vm_ip][k] = v
-        except socket.error:
-          print 'Cannot connect to %s to read VMWare tags' % hostname
-
-    if tagName in vmwareTags[vm_ip]:
-      return vmwareTags[vm_ip][tagName]
-    else:
+    secure=ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    secure.verify_mode=ssl.CERT_NONE
+    try:
+      with open(DEFAULT_VMWARE_CONFIG, 'r') as vmwareConfig:
+        vcenters = toml.load(vmwareConfig)['vcenters']
+    except IOError as error:
+      print "Could not open %s" % DEFAULT_VMWARE_CONFIG
       return None
+
+    for k,v in vcenters.iteritems():
+      hostname = v.get('hostname')
+      username = v.get('user')
+      password = v.get('password')
+      try:
+        si= SmartConnect(host=hostname, user=username, pwd=password, sslContext=secure)
+        searcher = si.content.searchIndex
+        vm = searcher.FindByIp(ip=vm_ip, vmSearch=True)
+        if vm:
+          f = si.content.customFieldsManager.field
+          for k, v in [(x.name, v.value) for x in f for v in vm.customValue if x.key == v.key]:
+            vmwareTags[vm_ip][k] = v
+
+      except socket.error:
+        print 'Cannot connect to %s to read VMWare tags' % hostname
+
+  if tagName in vmwareTags[vm_ip]:
+    return vmwareTags[vm_ip][tagName]
+  else:
+    return None
 
 
 def loadHostname():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you're unsure about anything in this checklist, don't hesitate to create a PR and ask. I'm happy to help! -->

# Description

* Switched from using IP address to UUID when looking up tag data. We were using the VM's IP address as the key when requesting tag information. This turned out to be a bad idea because if the machine has several IPs, the one `getIP()` picked wasn't necessarily the one vSphere was using as the main key, so you wouldn't always be able to get the tag data, which sucks.
* For efficiency, we now check the `vmwareTags` dict to see if we've already read a tag value  _before_ reading all the tags from the hypervisor. We also load all available tags into the cache whenever we scan for a tag that isn't already cached.
* Added `detectVSphereHost()`, `loadVSphereSettings()` and `writeVSphereSettings()` so we don't retry connecting to all the vSphere hosts listed in `vmware.toml` every time we read a tag, with the associated delays waiting for timeouts trying to connect to unreachable hypervisors. Now we store that information in a knob file so future `sourdough` runs won't have to grovel through the entire hypervisor list.
* Added a debugging flag file, `/etc/sourdough/debug-sourdough`.  When the flag is present, `sourdough` won't actually start `chef-client` so you can debug vSphere issues faster.
* Renamed `get_ip()` to `getIP()` for naming consistency
* Converted a lot of crappy `print` statements to proper `logger` usage
* Updated and created a bunch of missing/crappy docstrings

# Copyright Assignment

- [x] This project is covered by the [Apache License](https://github.com/unixorn/sourdough/blob/master/License.md), and I agree to contribute this PR under the terms of the license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] All new and existing tests passed.