### PR TITLE
Fix thinko in writeKnob

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## 0.12.4
 
+Fix error in writeKnob - we were trying to call this.logger directly instead of this.logger.error
+
+## 0.12.4
+
 Added `sourdough-enable-chef`, `sourdough-disable-chef`, `sourdough-enable-debugging` and `sourdough-disable-debugging` convenience commands.
 
 ## 0.12.3

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def system_call(command):
 
 
 name = 'sourdough'
-version = '0.12.4'
+version = '0.12.5'
 
 
 class CleanCommand(Command):

--- a/sourdough/sourdough.py
+++ b/sourdough/sourdough.py
@@ -155,7 +155,7 @@ def writeKnob(name, value, knobDirectory='/etc/knobs'):
   loadSharedLogger()
   knobPath = "%s/%s" % (knobDirectory, name)
   if not os.path.isdir(knobDirectory):
-    this.logger('directory %s does not exist, creating it', knobDirectory)
+    this.logger.error('directory %s does not exist, creating it', knobDirectory)
     systemCall('mkdir -p %s' % knobDirectory)
   if value is not None:
     with open(knobPath, 'w') as knobFile:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you're unsure about anything in this checklist, don't hesitate to create a PR and ask. I'm happy to help! -->

# Description

We were calling this.logger directly instead of this.logger.error
when creating `/etc/knobs` if it was missing. This was only exposed
on AmazonLinux because our AMI already has `/etc/knobs` created.

# Copyright Assignment

- [x] This project is covered by the [Apache License](https://github.com/unixorn/sourdough/blob/master/License.md), and I agree to contribute this PR under the terms of the license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
